### PR TITLE
fix union sql. add parentheses.

### DIFF
--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala
@@ -205,10 +205,8 @@ trait QueryDSLFeature {
 
   // factory
   private[scalikejdbc] object PagingSQLBuilder {
-    def apply[A](sql: SQLSyntax): RawSQLBuilder[A] with PagingSQLBuilder[A] = {
-      println(s"create $sql")
+    def apply[A](sql: SQLSyntax): RawSQLBuilder[A] with PagingSQLBuilder[A] =
       new RawSQLBuilder[A](sql) with PagingSQLBuilder[A]
-    }
   }
 
   trait PagingSQLBuilder[A]

--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala
@@ -205,8 +205,10 @@ trait QueryDSLFeature {
 
   // factory
   private[scalikejdbc] object PagingSQLBuilder {
-    def apply[A](sql: SQLSyntax): RawSQLBuilder[A] with PagingSQLBuilder[A] =
+    def apply[A](sql: SQLSyntax): RawSQLBuilder[A] with PagingSQLBuilder[A] = {
+      println(s"create $sql")
       new RawSQLBuilder[A](sql) with PagingSQLBuilder[A]
+    }
   }
 
   trait PagingSQLBuilder[A]
@@ -489,12 +491,12 @@ trait QueryDSLFeature {
   trait UnionQuerySQLBuilder[A] extends SQLBuilder[A] {
     def union(anotherQuery: SQLSyntax): PagingSQLBuilder[A] =
       PagingSQLBuilder[A](
-        sqls"${considerRoundBracket(sql)} union ${considerRoundBracket(anotherQuery)}"
+        sqls"${withRoundBracket(sql)} union ${withRoundBracket(anotherQuery)}"
       )
 
     def unionAll(anotherQuery: SQLSyntax): PagingSQLBuilder[A] =
       PagingSQLBuilder[A](
-        sqls"${considerRoundBracket(sql)} union all ${considerRoundBracket(anotherQuery)}"
+        sqls"${withRoundBracket(sql)} union all ${withRoundBracket(anotherQuery)}"
       )
 
     def union(anotherQuery: SQLBuilder[_]): PagingSQLBuilder[A] = union(
@@ -504,10 +506,12 @@ trait QueryDSLFeature {
       anotherQuery.toSQLSyntax
     )
 
-    private def considerRoundBracket(sqlQuery: SQLSyntax): SQLSyntax =
-      if (sqlQuery.value.startsWith("(") && sqlQuery.value.endsWith(")"))
+    private def withRoundBracket(sqlQuery: SQLSyntax): SQLSyntax = {
+      val statement = sqlQuery.value.trim()
+      if (statement.startsWith("(") && statement.endsWith(")"))
         sqlQuery
       else sqls"(${sqlQuery})"
+    }
   }
 
   /**
@@ -658,11 +662,11 @@ trait QueryDSLFeature {
 
     def union(anotherQuery: SQLSyntax): PagingSQLBuilder[A] =
       PagingSQLBuilder[A](
-        sqls"${considerRoundBracket(toSQLSyntax)} union ${considerRoundBracket(anotherQuery)}"
+        sqls"${withRoundBracket(toSQLSyntax)} union ${withRoundBracket(anotherQuery)}"
       )
     def unionAll(anotherQuery: SQLSyntax): PagingSQLBuilder[A] =
       PagingSQLBuilder[A](
-        sqls"${considerRoundBracket(toSQLSyntax)} union all ${considerRoundBracket(anotherQuery)}"
+        sqls"${withRoundBracket(toSQLSyntax)} union all ${withRoundBracket(anotherQuery)}"
       )
 
     def union(anotherQuery: SQLBuilder[_]): PagingSQLBuilder[A] = union(
@@ -716,10 +720,12 @@ trait QueryDSLFeature {
       mapper: SelectSQLBuilder[A] => SelectSQLBuilder[A]
     ): SelectSQLBuilder[A] = mapper.apply(this)
 
-    private def considerRoundBracket(sqlSyntax: SQLSyntax): SQLSyntax =
-      if (sqlSyntax.value.startsWith("(") && sqlSyntax.value.endsWith(")"))
+    private def withRoundBracket(sqlSyntax: SQLSyntax): SQLSyntax = {
+      val statement = sqlSyntax.value.trim()
+      if (statement.startsWith("(") && statement.endsWith(")"))
         sqlSyntax
       else sqls"(${sqlSyntax})"
+    }
 
     private def lazyLoadedPart: SQLSyntax =
       sqls"select ${sqls.join(resultAllProviders.reverseIterator.map(_.resultAll).toSeq, sqls",")}"

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
@@ -784,6 +784,38 @@ class QueryInterfaceSpec
         }.map(_.int("id")).list.apply()
         unionResults should equal(List(4, 3, 2))
 
+        // union with limit within a subexpression (fix #1391)
+        val unionResultsWithLimit = withSQL {
+          select(sqls"${a.id} as id")
+            .from(Account as a)
+            .union(
+              select(sqls"${p.id} as id")
+                .from(Product as p)
+                .limit(1)
+            )
+            .orderBy(sqls"id")
+            .desc
+            .limit(3)
+            .offset(0)
+        }.map(_.int("id")).list.apply()
+        unionResultsWithLimit should equal(List(4, 3, 2))
+
+        // union with order by within a subexpression (fix #1391)
+        val unionResultsWithOrderBy = withSQL {
+          select(sqls"${a.id} as id")
+            .from(Account as a)
+            .union(
+              select(sqls"${p.id} as id")
+                .from(Product as p)
+                .orderBy(p.id)
+            )
+            .orderBy(sqls"id")
+            .desc
+            .limit(3)
+            .offset(0)
+        }.map(_.int("id")).list.apply()
+        unionResultsWithOrderBy should equal(List(4, 3, 2))
+
         // union all
         val unionAllResults = withSQL {
           select(a.id)
@@ -792,6 +824,25 @@ class QueryInterfaceSpec
             .unionAll(select(p.id).from(Product as p))
         }.map(_.int(1)).list.apply()
         unionAllResults should equal(List(1, 2, 3, 4, 1, 2, 1, 2))
+
+        // union all with limit within a subexpression (fix #1391)
+        val unionAllResultsWithLimit = withSQL {
+          select(a.id)
+            .from(Account as a)
+            .unionAll(select(p.id).from(Product as p).limit(1))
+            .unionAll(select(p.id).from(Product as p))
+        }.map(_.int(1)).list.apply()
+        unionAllResultsWithLimit should equal(List(1, 2, 3, 4, 1, 1, 2))
+
+        // union all with limit within a subexpression (fix #1391)
+        val unionAllResultsWithOrderBy = withSQL {
+          select(a.id)
+            .from(Account as a)
+            .orderBy(a.id)
+            .unionAll(select(p.id).from(Product as p).orderBy(sqls"id"))
+            .unionAll(select(p.id).from(Product as p))
+        }.map(_.int(1)).list.apply()
+        unionAllResultsWithOrderBy should equal(List(1, 2, 3, 4, 1, 2, 1, 2))
 
         // except
         // MySQL doesn't support except

--- a/scalikejdbc-joda-time/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
+++ b/scalikejdbc-joda-time/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
@@ -761,6 +761,22 @@ class QueryInterfaceSpec
         }.map(_.int("id")).list.apply()
         unionResults should equal(List(4, 3, 2))
 
+        // union with order by
+        val unionResultsWithOrderBy = withSQL {
+          select(sqls"${a.id} as id")
+            .from(Account as a)
+            .union(
+              select(sqls"${p.id} as id")
+                .from(Product as p)
+                .orderBy(p.id)
+            )
+            .orderBy(sqls"id")
+            .desc
+            .limit(3)
+            .offset(0)
+        }.map(_.int("id")).list.apply()
+        unionResultsWithOrderBy should equal(List(4, 3, 2))
+
         // union all
         val unionAllResults = withSQL {
           select(a.id)
@@ -769,6 +785,23 @@ class QueryInterfaceSpec
             .unionAll(select(p.id).from(Product as p))
         }.map(_.int(1)).list.apply()
         unionAllResults should equal(List(1, 2, 3, 4, 1, 2, 1, 2))
+
+        // union all with order by
+        val unionAllResultsWithOrderBy = withSQL {
+          select(a.id)
+            .from(Account as a)
+            .unionAll(
+              select(p.id)
+                .from(Product as p)
+                .orderBy(p.id)
+            )
+            .unionAll(
+              select(p.id)
+                .from(Product as p)
+                .orderBy(p.id)
+            )
+        }.map(_.int(1)).list.apply()
+        unionAllResultsWithOrderBy should equal(List(1, 2, 3, 4, 1, 2, 1, 2))
 
         // except
         // MySQL doesn't support except


### PR DESCRIPTION
fix xxxx

- Add round bracket when using union syntax.
- A reason a function is branched is mysql seems to disallow double round bracket (even so postgres and h2 allow it.)
